### PR TITLE
GitHub pagination

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,14 +1,15 @@
 /* Use import to require files as not to clash with bootstrap gem */
 
+@import "main";
+@import "comments";
+@import "project";
+
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "select2";
 @import "select2-bootstrap";
 @import "bootswatch";
 @import "bootstrap-datepicker3";
-@import "main";
-@import "comments";
-@import "project";
 @import "font-awesome";
 @import "dataTables.bootstrap";
 

--- a/app/controllers/github_sync_controller.rb
+++ b/app/controllers/github_sync_controller.rb
@@ -1,7 +1,8 @@
 class GithubSyncController < ApplicationController
   def index
+    page = params[:page]
     github = Github.new
-    repos = github.get_all_repos
+    repos = github.get_all_repos(page)
 
     existing_repo_names = Project.pluck(:github_identifier)
     

--- a/app/controllers/github_sync_controller.rb
+++ b/app/controllers/github_sync_controller.rb
@@ -1,8 +1,8 @@
 class GithubSyncController < ApplicationController
   def index
-    page = params[:page]
+    @page = params[:page]
     github = Github.new
-    repos = github.get_all_repos(page)
+    repos = github.get_all_repos(@page)
 
     existing_repo_names = Project.pluck(:github_identifier)
     
@@ -16,7 +16,8 @@ class GithubSyncController < ApplicationController
 
     if contains_invalid_repository? repos
       github = Github.new
-      repositories = github.get_all_repos # thus
+      @page = params[:page]
+      repositories = github.get_all_repos(@page)
 
       @link_headers = repositories.shift
       @repos = repositories

--- a/app/controllers/github_sync_controller.rb
+++ b/app/controllers/github_sync_controller.rb
@@ -16,10 +16,10 @@ class GithubSyncController < ApplicationController
 
     if contains_invalid_repository? repos
       github = Github.new
-      repos = github.get_all_repos
+      repositories = github.get_all_repos # thus
 
-      @link_headers = repos.shift
-      @repos = repos
+      @link_headers = repositories.shift
+      @repos = repositories
       @errored_repos = repos.select { |r| r.errors }
       render :index
     else

--- a/app/controllers/github_sync_controller.rb
+++ b/app/controllers/github_sync_controller.rb
@@ -1,7 +1,12 @@
 class GithubSyncController < ApplicationController
   def index
+    github = Github.new
+    repos = github.get_all_repos
+
     existing_repo_names = Project.pluck(:github_identifier)
-    @repos = Github.repos.reject{ |repo| existing_repo_names.include?(repo.full_name) }
+    
+    @link_headers = repos.shift
+    @repos = repos.reject{ |repo| existing_repo_names.include?(repo.full_name) }
   end
 
   def sync
@@ -9,7 +14,11 @@ class GithubSyncController < ApplicationController
     repos = github_sync.run
 
     if contains_invalid_repository? repos
-      @repos = Github.repos
+      github = Github.new
+      repos = github.get_all_repos
+
+      @link_headers = repos.shift
+      @repos = repos
       @errored_repos = repos.select { |r| r.errors }
       render :index
     else

--- a/app/models/github_project_synchroniser.rb
+++ b/app/models/github_project_synchroniser.rb
@@ -8,7 +8,9 @@ class GithubProjectSynchroniser
   # Returns an array of the projects to loop through for errors
   def run
     @repo_names.map! { |name|
-      repo = Github.get_repo(name)
+      github = Github.new
+      repo = github.get_single_repo(name)
+
       Project.where(github_identifier: repo.full_name).first_or_create do |r|
         r.title = repo.name
         r.state = "Under Development"

--- a/app/models/github_project_synchroniser.rb
+++ b/app/models/github_project_synchroniser.rb
@@ -15,7 +15,7 @@ class GithubProjectSynchroniser
         r.title = repo.name
         r.state = "Under Development"
         r.github_identifier = repo.full_name
-        r.description = repo.description.presence || '(empty)'
+        r.description = repo.description
       end
     }.compact
   end

--- a/app/services/github.rb
+++ b/app/services/github.rb
@@ -1,13 +1,27 @@
 class Github
-  # Returns an array of hashes of all (public so far) unepwcmc repositories
-  def self.repos
+  def initialize
+    @repos
+  end
+
+  # Returns an array of hashes of all (public so far) unepwcmc repositories with the first element as a hash of link header info
+  def get_all_repos
     response = HTTParty.get("https://api.github.com/orgs/unepwcmc/repos?client_id=#{Rails.application.secrets.github_key}&client_secret=#{Rails.application.secrets.github_secret}", headers: {"User-Agent" => "Labs"})
-    JSON.parse(response.body).map { |repo| OpenStruct.new(repo) }
+    repos_array = JSON.parse(response.body).map { |repo| OpenStruct.new(repo) }
+    @repos = repos_array.unshift(parse_link_headers(response.headers['link']))
   end
 
   # Takes a repo name and returns its information in an openstruct hash
-  def self.get_repo name
+  def get_single_repo name
     response = HTTParty.get("https://api.github.com/repos/unepwcmc/#{name}?client_id=#{Rails.application.secrets.github_key}&client_secret=#{Rails.application.secrets.github_secret}", headers: {"User-Agent" => "Labs"})
     OpenStruct.new(JSON.parse(response.body))
   end
+
+  private
+    # Parses github link header string into a sensible hash format
+    def parse_link_headers headers
+      array = headers.delete(' ').gsub(/[\"\\\<\>]/, '').gsub(/rel=/, '').split(',').map {|e| e.split(';').reverse }
+      pages = []
+      array.each { |e| pages << ["#{e.first}_page", e[1].last] }
+      Hash[array.zip(pages).flatten!(1)]
+    end
 end

--- a/app/services/github.rb
+++ b/app/services/github.rb
@@ -4,8 +4,9 @@ class Github
   end
 
   # Returns an array of hashes of all (public so far) unepwcmc repositories with the first element as a hash of link header info
-  def get_all_repos
-    response = HTTParty.get("https://api.github.com/orgs/unepwcmc/repos?client_id=#{Rails.application.secrets.github_key}&client_secret=#{Rails.application.secrets.github_secret}", headers: {"User-Agent" => "Labs"})
+  # Pass in a page number for github pagination, defaults to 1
+  def get_all_repos page = 1
+    response = HTTParty.get("https://api.github.com/orgs/unepwcmc/repos?client_id=#{Rails.application.secrets.github_key}&client_secret=#{Rails.application.secrets.github_secret}&page=#{page}", headers: {"User-Agent" => "Labs"})
     repos_array = JSON.parse(response.body).map { |repo| OpenStruct.new(repo) }
     @repos = repos_array.unshift(parse_link_headers(response.headers['link']))
   end
@@ -21,7 +22,7 @@ class Github
     def parse_link_headers headers
       array = headers.delete(' ').gsub(/[\"\\\<\>]/, '').gsub(/rel=/, '').split(',').map {|e| e.split(';').reverse }
       pages = []
-      array.each { |e| pages << ["#{e.first}_page", e[1].last] }
+      array.each { |e| pages << ["#{e.first}_page", e[1].last.to_i] }
       Hash[array.zip(pages).flatten!(1)]
     end
 end

--- a/app/views/github_sync/index.html.erb
+++ b/app/views/github_sync/index.html.erb
@@ -3,6 +3,8 @@
 
 <%= render 'error_messages' %>
 
+<%= @link_headers.inspect %>
+
 <%= form_tag sync_projects_path do %>
   <table class="table" id="sync_table">
     <thead>

--- a/app/views/github_sync/index.html.erb
+++ b/app/views/github_sync/index.html.erb
@@ -11,6 +11,7 @@
 </nav>
 
 <%= form_tag sync_projects_path do %>
+  <%= hidden_field_tag 'page', @page %>
   <table class="table" id="sync_table">
     <thead>
       <tr>

--- a/app/views/github_sync/index.html.erb
+++ b/app/views/github_sync/index.html.erb
@@ -3,7 +3,12 @@
 
 <%= render 'error_messages' %>
 
-<%= @link_headers.inspect %>
+<nav>
+  <ul class="pagination">
+    <li><%= link_to 'Previous 25', sync_projects_path(page: @link_headers['prev_page']) if @link_headers.try(:[], 'prev_page') %></li>
+    <li><%= link_to 'Next 25', sync_projects_path(page: @link_headers['next_page']) if @link_headers.try(:[], 'next_page') %></li>
+  </ul>
+</nav>
 
 <%= form_tag sync_projects_path do %>
   <table class="table" id="sync_table">

--- a/test/controllers/github_sync_controller_test.rb
+++ b/test/controllers/github_sync_controller_test.rb
@@ -11,7 +11,7 @@ class GithubSyncControllerTest < ActionController::TestCase
   test "should get index" do
     stub_request(:get, "https://api.github.com/orgs/unepwcmc/repos?client_id=&client_secret=&page=").
     with(:headers => {'User-Agent'=>'Labs'}).
-    to_return(:status => 200, :body => [{name: 'derp', full_name: "herp", description: 'derp'}].to_json) 
+    to_return(:status => 200, :body => [{name: 'derp', full_name: "herp", description: 'derp'}].to_json, :headers => {'link' => '<https://api.github.com/organizations/513080/repos?client_id=&client_secret=&page=2>; rel="next", <https://api.github.com/organizations/513080/repos?client_id=&client_secret=&page=3>; rel="last"'}) 
 
     get :index
     assert_response :success

--- a/test/controllers/github_sync_controller_test.rb
+++ b/test/controllers/github_sync_controller_test.rb
@@ -9,7 +9,7 @@ class GithubSyncControllerTest < ActionController::TestCase
   end
 
   test "should get index" do
-    stub_request(:get, "https://api.github.com/orgs/unepwcmc/repos?client_id=&client_secret=").
+    stub_request(:get, "https://api.github.com/orgs/unepwcmc/repos?client_id=&client_secret=&page=").
     with(:headers => {'User-Agent'=>'Labs'}).
     to_return(:status => 200, :body => [{name: 'derp', full_name: "herp", description: 'derp'}].to_json) 
 

--- a/test/controllers/github_sync_controller_test.rb
+++ b/test/controllers/github_sync_controller_test.rb
@@ -20,11 +20,11 @@ class GithubSyncControllerTest < ActionController::TestCase
   test "should create a project on post to sync" do
     stub_request(:get, "https://api.github.com/orgs/unepwcmc/repos?client_id=&client_secret=").
     with(:headers => {'User-Agent'=>'Labs'}).
-    to_return(:status => 200, :body => [{"name" => 'derp', "full_name" => "unepwcmc/herp", "description" => 'derp'}].to_json, :headers => {})
+    to_return(:status => 200, :body => [{"name" => 'derp', "full_name" => "unepwcmc/herp", "description" => 'derp'}].to_json, :headers => {'link' => '<https://api.github.com/organizations/513080/repos?client_id=&client_secret=&page=2>; rel="next", <https://api.github.com/organizations/513080/repos?client_id=&client_secret=&page=3>; rel="last"'})
 
     stub_request(:get, "https://api.github.com/repos/unepwcmc/first_repo?client_id=&client_secret=").
     with(:headers => {'User-Agent'=>'Labs'}).
-    to_return(:status => 200, :body => {"name" => 'derp', "full_name" => "unepwcmc/herp", "description" => 'derp'}.to_json, :headers => {})
+    to_return(:status => 200, :body => {"name" => 'derp', "full_name" => "unepwcmc/herp", "description" => 'derp'}.to_json, :headers => {'link' => '<https://api.github.com/organizations/513080/repos?client_id=&client_secret=&page=2>; rel="next", <https://api.github.com/organizations/513080/repos?client_id=&client_secret=&page=3>; rel="last"'})
 
     assert_difference 'Project.count' do
       post :sync, repos: ["first_repo"]


### PR DESCRIPTION
- Refactored github service object to take optional page parameter (defaults to 1 if not specified)
- get_all_repos now returns the github link headers in a hash as its first object
- Link headers passed as instance variable to template now
- Updated views to generate prev and next buttons based on link headers
