### PR TITLE
Little fix to broken comments along with some updates

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,7 +6,7 @@ class CommentsController < ApplicationController
     @comment = @commentable.comments.new(comment_params)
     @comment.user_id = current_user.id
 
-    SlackChannel.post("#labs", @comment.content)
+    SlackChannel.post("#labs", "New comments in Labs", @comment.content, ":envelope:")
 
     respond_to do |format|
       if @comment.save
@@ -17,7 +17,7 @@ class CommentsController < ApplicationController
       end
     end
   end
-  
+
   def destroy
     @comment = Comment.find(params[:id])
     @comment.destroy
@@ -29,7 +29,7 @@ class CommentsController < ApplicationController
   end
 
   private
-  
+
   def load_commentable
     resource, id = request.path.split('/')[1, 2]
     @commentable = resource.singularize.classify.constantize.find(id)

--- a/app/controllers/installations_controller.rb
+++ b/app/controllers/installations_controller.rb
@@ -52,7 +52,7 @@ class InstallationsController < ApplicationController
       if old_closing != @installation.closing
         status = @installation.closing ? "scheduled for close down" : "unscheduled for close down"
         message = "*#{@installation.name}* installation has been #{status}"
-        SlackChannel.post("#labs", "New comments in Labs", message, ":envelope:")
+        SlackChannel.post("#labs", "Labs detective", message, ":squirrel:")
       end
       flash[:notice] = 'Installation was successfully updated'
     end

--- a/app/controllers/project_instances_controller.rb
+++ b/app/controllers/project_instances_controller.rb
@@ -45,7 +45,7 @@ class ProjectInstancesController < ApplicationController
         end
         status = @project_instance.closing ? "scheduled for close down" : "unscheduled for close down"
         message = "*#{@project_instance.name}* project instance and its installations have been #{status}"
-        SlackChannel.post("#labs", "New comments in Labs", message, ":envelope:")
+        SlackChannel.post("#labs", "Labs detective", message, ":squirrel:")
       end
       flash[:notice] = "Instance was successfully updated."
     end


### PR DESCRIPTION
The standard commenting system was broken due to an outdated SlackChannel post call.
- Updated SlackChannel post call
- Updated icon and username for comments fired by updates in installations and project instances