### PR TITLE
Close down flags for servers

### DIFF
--- a/app/controllers/installations_controller.rb
+++ b/app/controllers/installations_controller.rb
@@ -46,16 +46,10 @@ class InstallationsController < ApplicationController
   def update
     set_installation
 
-    old_closing = @installation.closing
-
-    if @installation.update_attributes(installation_params)
-      if old_closing != @installation.closing
-        status = @installation.closing ? "scheduled for close down" : "unscheduled for close down"
-        message = "*#{@installation.name}* installation has been #{status}"
-        SlackChannel.post("#labs", "Labs detective", message, ":squirrel:")
-      end
+    SlackChannel.closing_notification(@installation, installation_params) do
       flash[:notice] = 'Installation was successfully updated'
     end
+
     respond_with(@installation)
   end
 

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -78,7 +78,7 @@ class ServersController < ApplicationController
   private
 
     def server_params
-      params.require(:server).permit(:name, :domain, :username, :admin_url, :os, :description, :ssh_key_name, :open_ports_array)
+      params.require(:server).permit(:name, :domain, :username, :admin_url, :os, :description, :ssh_key_name, :open_ports_array, :closing)
     end
 
     def comment_params

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -32,7 +32,10 @@ class ServersController < ApplicationController
   def update
     @server = Server.with_deleted.find(params[:id])
 
-    flash[:notice] = 'Server was successfully updated.' if @server.update_attributes(server_params)
+    SlackChannel.closing_notification(@server, server_params) do
+      flash[:notice] = 'Server was successfully updated.'
+    end
+
     respond_with(@server)
   end
 

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -13,6 +13,7 @@
 #  updated_at   :datetime
 #  ssh_key_name :text
 #  open_ports   :text             default([]), is an Array
+#  closing      :boolean          default(FALSE)
 #
 
 class Server < ActiveRecord::Base

--- a/app/services/slack_channel.rb
+++ b/app/services/slack_channel.rb
@@ -2,6 +2,19 @@ require 'httparty'
 require 'yaml'
 
 class SlackChannel
+
+  def self.closing_notification(obj, _params)
+    closing_flag = obj.closing
+    if obj.update_attributes(_params)
+      if closing_flag != obj.closing
+        status = obj.closing ? "scheduled for close down" : "unscheduled for close down"
+        message = "*#{obj.name}* #{obj.class.name.downcase} has been #{status}"
+        post("#labs", "Labs detective (#{Rails.env})", message, ":squirrel:")
+      end
+      yield
+    end
+  end
+
   def self.post channel, username, message, icon
     url = Rails.application.secrets.slack_notification_webhook_url
 

--- a/app/views/servers/_form.html.erb
+++ b/app/views/servers/_form.html.erb
@@ -67,6 +67,18 @@
     </div>
   </div>
 
+  <% unless @server.new_record? %>
+    <div class="form-group">
+      <div class="col-sm-2 control-label">
+        <%= f.label :closing %>
+      </div>
+      <div class="col-sm-offset-2 col-sm-10" style="margin: 10px 0px 0px 0px;">
+        <%= f.check_box :closing, class: "inline" %>
+        <p class="help-block">Select if retirement scheduled.</p>
+      </div>
+    </div>
+  <% end %>
+
   <div class="actions">
     <%= f.submit class: "btn btn-primary" %>
     <% unless @server.new_record? %>

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -46,6 +46,13 @@
       <strong>Open ports:</strong>
       <%= @server.open_ports_array %>
     </p>
+
+    <% if !@server.deleted? %>
+      <p>
+        <strong>Scheduled for close down:</strong>
+        <span class='closing'><%= @server.closing %></span>
+      </p>
+    <% end %>
   </div>
 
   <div class="col-lg-6">

--- a/db/migrate/20160701133223_add_closing_column_to_servers.rb
+++ b/db/migrate/20160701133223_add_closing_column_to_servers.rb
@@ -1,0 +1,5 @@
+class AddClosingColumnToServers < ActiveRecord::Migration
+  def change
+    add_column :servers, :closing, :boolean, default: false
+  end
+end

--- a/test/controllers/installations_controller_test.rb
+++ b/test/controllers/installations_controller_test.rb
@@ -62,9 +62,19 @@ class InstallationsControllerTest < ActionController::TestCase
 
   test "should send a notification when closing installation" do
     message = "*#{@installation.name}* installation has been scheduled for close down"
-    SlackChannel.expects(:post).with("#labs", "Labs detective", message, ":squirrel:")
+    SlackChannel.expects(:post).with("#labs", "Labs detective (test)", message, ":squirrel:")
     patch :update, id: @installation, installation: {
       closing: true
+    }
+    assert_redirected_to installation_path(assigns(:installation))
+  end
+
+  test "should send a notification when re-opening installation" do
+    installation = FactoryGirl.create(:installation, {closing: true})
+    message = "*#{installation.name}* installation has been unscheduled for close down"
+    SlackChannel.expects(:post).with("#labs", "Labs detective (test)", message, ":squirrel:")
+    patch :update, id: installation, installation: {
+      closing: false
     }
     assert_redirected_to installation_path(assigns(:installation))
   end

--- a/test/controllers/project_instances_controller_test.rb
+++ b/test/controllers/project_instances_controller_test.rb
@@ -110,6 +110,25 @@ class ProjectInstancesControllerTest < ActionController::TestCase
     assert_not_nil assigns(:projects_instances)
   end
 
+  test "should send a notification when closing project_instance" do
+    message = "*#{@project_instance.name}* projectinstance has been scheduled for close down"
+    SlackChannel.expects(:post).with("#labs", "Labs detective (test)", message, ":squirrel:")
+    patch :update, id: @project_instance, project_instance: {
+      closing: true
+    }
+    assert_redirected_to project_instance_path(assigns(:project_instance))
+  end
+
+  test "should send a notification when re-opening project_instance" do
+    project_instance = FactoryGirl.create(:project_instance, {closing: true})
+    message = "*#{project_instance.name}* projectinstance has been unscheduled for close down"
+    SlackChannel.expects(:post).with("#labs", "Labs detective (test)", message, ":squirrel:")
+    patch :update, id: project_instance, project_instance: {
+      closing: false
+    }
+    assert_redirected_to project_instance_path(assigns(:project_instance))
+  end
+
   test "should cascade closing flag to installations" do
     stub_slack_comment do
       patch :update, id: @project_instance_with_installations, project_instance:

--- a/test/controllers/servers_controller_test.rb
+++ b/test/controllers/servers_controller_test.rb
@@ -103,4 +103,23 @@ class ServersControllerTest < ActionController::TestCase
     end
   end
 
+  test "should send a notification when closing server" do
+    message = "*#{@server.name}* server has been scheduled for close down"
+    SlackChannel.expects(:post).with("#labs", "Labs detective (test)", message, ":squirrel:")
+    patch :update, id: @server, server: {
+      closing: true
+    }
+    assert_redirected_to server_path(assigns(:server))
+  end
+
+  test "should send a notification when re-opening server" do
+    server = FactoryGirl.create(:server, {closing: true})
+    message = "*#{server.name}* server has been unscheduled for close down"
+    SlackChannel.expects(:post).with("#labs", "Labs detective (test)", message, ":squirrel:")
+    patch :update, id: server, server: {
+      closing: false
+    }
+    assert_redirected_to server_path(assigns(:server))
+  end
+
 end

--- a/test/factories/servers.rb
+++ b/test/factories/servers.rb
@@ -24,6 +24,7 @@ FactoryGirl.define do
     description Faker::Lorem.paragraph
     ssh_key_name Faker::Lorem.paragraph
     open_ports [ Faker::Number.number(8), Faker::Number.number(8), Faker::Number.number(8)]
+    closing false
 
     factory :server_with_installations do
 


### PR DESCRIPTION
This PR [adds closing functionality to servers](https://www.pivotaltracker.com/story/show/97791174) as already existing for installations and project_instances.
There's also some refactoring involved about extracting the common functionality of sending slack notifications.
Tests updated as well.
Migration required.