### PR TITLE
Auto populate rails and ruby version from GitHub

### DIFF
--- a/app/models/github_project_synchroniser.rb
+++ b/app/models/github_project_synchroniser.rb
@@ -16,6 +16,8 @@ class GithubProjectSynchroniser
         r.state = "Under Development"
         r.github_identifier = repo.full_name
         r.description = repo.description
+        r.rails_version = github.get_rails_version(name) || ''
+        r.ruby_version = github.get_ruby_version(name)
       end
     }.compact
   end

--- a/app/models/github_project_synchroniser.rb
+++ b/app/models/github_project_synchroniser.rb
@@ -16,7 +16,7 @@ class GithubProjectSynchroniser
         r.state = "Under Development"
         r.github_identifier = repo.full_name
         r.description = repo.description
-        r.rails_version = github.get_rails_version(name) || ''
+        r.rails_version = github.get_rails_version(name)
         r.ruby_version = github.get_ruby_version(name)
       end
     }.compact

--- a/app/services/github.rb
+++ b/app/services/github.rb
@@ -22,6 +22,21 @@ class Github
     OpenStruct.new(JSON.parse(response.body))
   end
 
+  def get_rails_version repo
+    url = "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/#{repo}/contents/Gemfile?#{CLIENT_CREDENTIALS}"
+    response = HTTParty.get(url, headers: {"User-Agent" => "Labs"})
+    return '' if response.body.match(/Not\sFound/)
+    content = Base64.decode64(JSON.parse(response.body)["content"])
+    content.match(/gem 'rails',\s'(~>\s)?(\d\.[\d+|\.]*)'/).try(:captures).try(:last)
+  end
+
+  def get_ruby_version repo
+    url = "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/#{repo}/contents/.ruby-version?#{CLIENT_CREDENTIALS}"
+    response = HTTParty.get(url, headers: {"User-Agent" => "Labs"})
+    return '' if response.body.match(/Not\sFound/)
+    Base64.decode64(JSON.parse(response.body)["content"]).delete!("\n")
+  end
+
   private
     # Parses github link header string into a sensible hash format
     def parse_link_headers headers

--- a/app/services/github.rb
+++ b/app/services/github.rb
@@ -27,7 +27,7 @@ class Github
     response = HTTParty.get(url, headers: {"User-Agent" => "Labs"})
     return '' if response.body.match(/Not\sFound/)
     content = Base64.decode64(JSON.parse(response.body)["content"])
-    content.match(/gem 'rails',\s'(~>\s)?(\d\.[\d+|\.]*)'/).try(:captures).try(:last)
+    content.match(/gem 'rails',\s'(~>\s)?(\d\.[\d+|\.]*)'/).try(:captures).try(:last) || ''
   end
 
   def get_ruby_version repo

--- a/lib/tasks/update_projects.rake
+++ b/lib/tasks/update_projects.rake
@@ -1,0 +1,19 @@
+namespace :update_projects do
+  task :rails_version => :environment do
+    Project.all.each do |project|
+      github = Github.new
+      repo = project.github_identifier.split('/').last
+      rails_version = github.get_rails_version(repo)
+      project.update_attributes(rails_version: rails_version) if rails_version.present?
+    end
+  end
+
+  task :ruby_version => :environment do
+    Project.all.each do |project|
+      github = Github.new
+      repo = project.github_identifier.split('/').last
+      ruby_version = github.get_ruby_version(repo)
+      project.update_attributes(ruby_version: ruby_version) if ruby_version.present?
+    end
+  end
+end

--- a/lib/tasks/update_projects.rake
+++ b/lib/tasks/update_projects.rake
@@ -1,19 +1,39 @@
 namespace :update_projects do
-  task :rails_version => :environment do
+  task :rails_version, [:arg] => :environment do |t, args|
     Project.all.each do |project|
       github = Github.new
       repo = project.github_identifier.split('/').last
       rails_version = github.get_rails_version(repo)
-      project.update_attributes(rails_version: rails_version) if rails_version.present?
+      if rails_version.present? && rails_version != project.rails_version
+        if project.update_attributes(rails_version: rails_version)
+          notice = ", UPDATED"
+        else
+          notice = ", ERRORED"
+        end
+      end
+      if args[:arg] == 'verbose'
+        notice = "#{repo}, fetched rails version: #{rails_version}#{notice}"
+        puts notice
+      end
     end
   end
 
-  task :ruby_version => :environment do
+  task :ruby_version, [:arg] => :environment do |t, args|
     Project.all.each do |project|
       github = Github.new
       repo = project.github_identifier.split('/').last
       ruby_version = github.get_ruby_version(repo)
-      project.update_attributes(ruby_version: ruby_version) if ruby_version.present?
+      if ruby_version.present? && ruby_version != project.ruby_version
+        if project.update_attributes(ruby_version: ruby_version)
+          notice = ", UPDATED"
+        else
+          notice = ", ERRORED"
+        end
+      end
+      if args[:arg] == 'verbose'
+        notice = "#{repo}, fetched ruby version: #{ruby_version}#{notice}"
+        puts notice
+      end
     end
   end
 end

--- a/test/controllers/github_sync_controller_test.rb
+++ b/test/controllers/github_sync_controller_test.rb
@@ -61,6 +61,36 @@ class GithubSyncControllerTest < ActionController::TestCase
       }
     )
 
+    stub_request(:get, "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/first_repo/contents/Gemfile?client_id=&client_secret=").
+    with(:headers => {'User-Agent'=>'Labs'}).
+    to_return(
+      :status => 200,
+      :body => {"name" => 'derp', "full_name" => "unepwcmc/herp", "description" => 'derp', "content" => "encoded content"}.to_json,
+      :headers => {
+        'link' =>
+        """
+          <#{Rails.application.secrets.github_api_base_url}organizations/513080/repos?
+          client_id=&client_secret=&page=2>; rel='next',
+          <#{Rails.application.secrets.github_api_base_url}organizations/513080/repos?client_id=&client_secret=&page=3>; rel='last'
+        """
+      }
+    )
+
+    stub_request(:get, "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/first_repo/contents/.ruby-version?client_id=&client_secret=").
+    with(:headers => {'User-Agent'=>'Labs'}).
+    to_return(
+      :status => 200,
+      :body => {"name" => 'derp', "full_name" => "unepwcmc/herp", "description" => 'derp', "content" => "encoded content"}.to_json,
+      :headers => {
+        'link' =>
+        """
+          <#{Rails.application.secrets.github_api_base_url}organizations/513080/repos?
+          client_id=&client_secret=&page=2>; rel='next',
+          <#{Rails.application.secrets.github_api_base_url}organizations/513080/repos?client_id=&client_secret=&page=3>; rel='last'
+        """
+      }
+    )
+
     assert_difference 'Project.count' do
       post :sync, repos: ["first_repo"]
     end


### PR DESCRIPTION
This is about [auto-populate rails and ruby versions from github](https://www.pivotaltracker.com/story/show/97714632).
There are two ways to achieve the auto-population:
  - when synchronising repos from github with the already existing functionality
  - through rake tasks(`update_projects:rails_version`, `update_projects:ruby_version`)
Tasks also have a `verbose` option to print some info while processing the update, in the format:
`#{repo_name}, fetched rails/ruby version: #{version}, UPDATED/ERRORED/empty`

Updated also some tests.