### PR TITLE
Projects update through webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ How it works:
   5. On the header of the Labs website, click on `Domains` to have a list of all the uploaded domains. Then choose one by clicking on the eye looking icon.
 
   6. On the left of the new page you will have a list of all entities of that project and by clicking on them you will have the corresponding E-R relationships showing as an image.
+
+TEST WEBHOOK

--- a/README.md
+++ b/README.md
@@ -35,4 +35,3 @@ How it works:
 
   6. On the left of the new page you will have a list of all entities of that project and by clicking on them you will have the corresponding E-R relationships showing as an image.
 
-TEST WEBHOOK

--- a/app/controllers/github_sync_controller.rb
+++ b/app/controllers/github_sync_controller.rb
@@ -5,9 +5,10 @@ class GithubSyncController < ApplicationController
     repos = github.get_all_repos(@page)
 
     existing_repo_names = Project.pluck(:github_identifier)
-    
+
     @link_headers = repos.shift
     @repos = repos.reject{ |repo| existing_repo_names.include?(repo.full_name) }
+      .sort_by { |repo| repo.full_name.downcase }
   end
 
   def sync

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -136,6 +136,17 @@ class Project < ActiveRecord::Base
     reviews.each{ |r| r.respond_to_project_update }
   end
 
+  def sync_with_github
+    github = Github.new
+    repo = self.github_identifier.split('/').last
+    project_params = {
+      rails_version: github.get_rails_version(repo),
+      ruby_version: github.get_ruby_version(repo)
+    }
+    self.update_attributes(project_params)
+  end
+
+
   private
 
   def validate_trello_ids

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Labs::Application.routes.draw do
 
   get '/projects/sync', to: 'github_sync#index', as: 'sync_projects'
   post '/projects/sync', to: 'github_sync#sync'
-  post '/projects/webhook', to: 'github_sync#webhook', as: 'webhook_projects'
+  post '/projects/push_event_webhook', to: 'github_sync#push_event_webhook', as: 'push_event_webhook'
 
   resources :reviews do
     resources :comments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Labs::Application.routes.draw do
 
   get '/projects/sync', to: 'github_sync#index', as: 'sync_projects'
   post '/projects/sync', to: 'github_sync#sync'
+  post '/projects/webhook', to: 'github_sync#webhook', as: 'webhook_projects'
 
   resources :reviews do
     resources :comments


### PR DESCRIPTION
Two stories in this PR:
  - [Alphabetical ordering of projects in sync page](https://www.pivotaltracker.com/story/show/125820951)
  - [Github webhook for push events in order to automatically update projects](https://www.pivotaltracker.com/story/show/125820951)

Regarding the latter, I've created a webhook at the organisation level, so when the master branch of one of our repositories is updated, it triggers an automatic update of specified project's attributes. At the moment just rails and ruby version are updated, but more fields could be retrieved later on after this PR is merged. The webhook URL needs to be updated as well, along with secrets.