### PR TITLE
changed authentication method to pass client id and secret through he…

### DIFF
--- a/app/services/github.rb
+++ b/app/services/github.rb
@@ -5,34 +5,33 @@ class Github
 
   # Returns an array of hashes of all (public so far) unepwcmc repositories with the first element as a hash of link header info
   # Pass in a page number for github pagination, defaults to 1
-
-  CLIENT_CREDENTIALS = "client_id=#{Rails.application.secrets.github_key}&client_secret=#{Rails.application.secrets.github_secret}"
+  CLIENT_CREDENTIALS = { username: Rails.application.secrets.github_key, password: Rails.application.secrets.github_secret }
 
   def get_all_repos page = 1
-    url = "#{Rails.application.secrets.github_api_base_url}orgs/unepwcmc/repos?#{CLIENT_CREDENTIALS}&page=#{page}"
-    response = HTTParty.get(url, headers: {"User-Agent" => "Labs"})
+    url = "#{Rails.application.secrets.github_api_base_url}orgs/unepwcmc/repos?page=#{page}"
+    response = HTTParty.get(url, basic_auth: CLIENT_CREDENTIALS, headers: {"User-Agent" => "Labs"})
     repos_array = JSON.parse(response.body).map { |repo| OpenStruct.new(repo) }
     @repos = repos_array.unshift(parse_link_headers(response.headers['link']))
   end
 
   # Takes a repo name and returns its information in an openstruct hash
   def get_single_repo name
-    url = "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/#{name}?#{CLIENT_CREDENTIALS}"
-    response = HTTParty.get(url, headers: {"User-Agent" => "Labs"})
+    url = "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/#{name}"
+    response = HTTParty.get(url, basic_auth: CLIENT_CREDENTIALS, headers: {"User-Agent" => "Labs"})
     OpenStruct.new(JSON.parse(response.body))
   end
 
   def get_rails_version repo
-    url = "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/#{repo}/contents/Gemfile?#{CLIENT_CREDENTIALS}"
-    response = HTTParty.get(url, headers: {"User-Agent" => "Labs"})
+    url = "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/#{repo}/contents/Gemfile"
+    response = HTTParty.get(url, basic_auth: CLIENT_CREDENTIALS, headers: {"User-Agent" => "Labs"})
     return '' if response.body.match(/Not\sFound/)
     content = Base64.decode64(JSON.parse(response.body)["content"])
     content.match(/gem 'rails',\s'(~>\s)?(\d\.[\d+|\.]*)'/).try(:captures).try(:last) || ''
   end
 
   def get_ruby_version repo
-    url = "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/#{repo}/contents/.ruby-version?#{CLIENT_CREDENTIALS}"
-    response = HTTParty.get(url, headers: {"User-Agent" => "Labs"})
+    url = "#{Rails.application.secrets.github_api_base_url}repos/unepwcmc/#{repo}/contents/.ruby-version"
+    response = HTTParty.get(url, basic_auth: CLIENT_CREDENTIALS, headers: {"User-Agent" => "Labs"})
     return '' if response.body.match(/Not\sFound/)
     Base64.decode64(JSON.parse(response.body)["content"]).delete!("\n")
   end


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/labs/tickets/3

See: https://github.com/omniauth/omniauth-github/pull/84, looks like the omniauth-github team fixed this back in February. I've also fixed the Github class as well to use basic authentication instead of outright passing the access key and token in the various get requests when fetching the list of projects etc. 

Can still see that our key is still being passed in the query (but not the token) though 