### PR TITLE
Fix/crop long urls

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import "product";
 @import "reviews";
 @import "domains";
+@import "helpers";
 
 @import "bootstrap-sprockets";
 @import "bootstrap";

--- a/app/assets/stylesheets/components/link.scss
+++ b/app/assets/stylesheets/components/link.scss
@@ -1,8 +1,0 @@
-.link {
-  &--product {
-    overflow: hidden;
-    text-overflow: ellipsis;
-
-    display: block;
-  }
-}

--- a/app/assets/stylesheets/components/link.scss
+++ b/app/assets/stylesheets/components/link.scss
@@ -1,0 +1,8 @@
+.link {
+  &--product {
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/helpers.scss
+++ b/app/assets/stylesheets/helpers.scss
@@ -1,0 +1,6 @@
+.overflow-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  display: block;
+}

--- a/app/assets/stylesheets/helpers.scss
+++ b/app/assets/stylesheets/helpers.scss
@@ -1,6 +1,7 @@
 .overflow-ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 
   display: block;
 }

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -22,13 +22,13 @@
 
     <p>
       <strong>Production:</strong>
-      <%= link_to @product.url, @product.url, target: '_blank' %>
+      <%= link_to @product.url, @product.url, target: '_blank', class: 'link--product' %>
     </p>
 
     <p>
       <strong>Staging:</strong>
       <% if @product.url_staging %>
-        <%= link_to @product.url_staging, @product.url_staging, target: '_blank' %>
+        <%= link_to @product.url_staging, @product.url_staging, target: '_blank', class: 'link--product' %>
       <% end %>
     </p>
 
@@ -209,7 +209,7 @@
   <div class="col-lg-6">
     <p>
       <strong>Documentation link:</strong>
-      <%= link_to @product.documentation_link, @product.documentation_link, target: '_blank' %>
+      <%= link_to @product.documentation_link, @product.documentation_link, target: '_blank', class: 'link--product' %>
     </p>
 
     <p>
@@ -238,7 +238,7 @@
     <p>
       <strong>Repository URL:</strong>
       <%= link_to @product.github_identifier,
-        "https://github.com/#{@product.github_identifier}"
+        "https://github.com/#{@product.github_identifier}", class: 'link--product'
       %>
     </p>
 
@@ -296,7 +296,7 @@
     <p><strong>Sharepoint Link</strong></p>
     <p>
      <% if !@product.sharepoint_link.blank? %>
-       <%= link_to @product.sharepoint_link, @product.sharepoint_link, target: '_blank' %>
+       <%= link_to @product.sharepoint_link, @product.sharepoint_link, target: '_blank', class: 'link--product' %>
       <% else %>
         This product has no Sharepoint link
       <% end %>
@@ -305,7 +305,7 @@
     <p><strong>Codebase Link</strong></p>
     <p>
       <% if !@product.codebase_url.blank? %>
-       <%= link_to @product.codebase_url, @product.codebase_url, target: '_blank' %>
+       <%= link_to @product.codebase_url, @product.codebase_url, target: '_blank', class: 'link--product' %>
       <% else %>
         This product has no Codebase link
       <% end %>
@@ -316,7 +316,7 @@
     <p><strong>Adobe XD design Link</strong></p>
     <p>
       <% if !@product.design_link.blank? %>
-       <%= link_to @product.design_link, @product.design_link, target: '_blank' %>
+       <%= link_to @product.design_link, @product.design_link, target: '_blank', class: 'link--product' %>
       <% else %>
         This product has no design link
       <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,7 +1,7 @@
 <%= review_jumbotron %>
 
 <div class="page-header product-header">
-	<%= link_to product_preview(@product)%>
+	<%= link_to product_preview(@product), class: 'link--product' %>
 	<h1><%= @product.title %></h1>
 	<div class="btn-group">
 	  <%= button_to 'Back', list_products_path, method: :get, :class => 'btn' %>
@@ -170,7 +170,7 @@
       <h2>This Product's Vulnerabilities</h2>
     </div>
       <%= link_to (image_tag("https://snyk.io/test/github/#{@product.github_identifier}/badge.svg", class: "badge_img",
-            alt: "No Vulnerabilities!")), "https://snyk.io/test/github/#{@product.github_identifier}", class: "badge_link"%>
+            alt: "No Vulnerabilities!")), "https://snyk.io/test/github/#{@product.github_identifier}", class: "badge_link link--product"%>
   </div>
 </div>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,7 +1,7 @@
 <%= review_jumbotron %>
 
 <div class="page-header product-header">
-	<%= link_to product_preview(@product), class: 'link--product' %>
+	<%= link_to product_preview(@product), class: 'overflow-ellipsis' %>
 	<h1><%= @product.title %></h1>
 	<div class="btn-group">
 	  <%= button_to 'Back', list_products_path, method: :get, :class => 'btn' %>
@@ -22,13 +22,13 @@
 
     <p>
       <strong>Production:</strong>
-      <%= link_to @product.url, @product.url, target: '_blank', class: 'link--product' %>
+      <%= link_to @product.url, @product.url, target: '_blank', class: 'overflow-ellipsis' %>
     </p>
 
     <p>
       <strong>Staging:</strong>
       <% if @product.url_staging %>
-        <%= link_to @product.url_staging, @product.url_staging, target: '_blank', class: 'link--product' %>
+        <%= link_to @product.url_staging, @product.url_staging, target: '_blank', class: 'overflow-ellipsis' %>
       <% end %>
     </p>
 
@@ -170,7 +170,7 @@
       <h2>This Product's Vulnerabilities</h2>
     </div>
       <%= link_to (image_tag("https://snyk.io/test/github/#{@product.github_identifier}/badge.svg", class: "badge_img",
-            alt: "No Vulnerabilities!")), "https://snyk.io/test/github/#{@product.github_identifier}", class: "badge_link link--product"%>
+            alt: "No Vulnerabilities!")), "https://snyk.io/test/github/#{@product.github_identifier}", class: "badge_link overflow-ellipsis"%>
   </div>
 </div>
 
@@ -209,7 +209,7 @@
   <div class="col-lg-6">
     <p>
       <strong>Documentation link:</strong>
-      <%= link_to @product.documentation_link, @product.documentation_link, target: '_blank', class: 'link--product' %>
+      <%= link_to @product.documentation_link, @product.documentation_link, target: '_blank', class: 'overflow-ellipsis' %>
     </p>
 
     <p>
@@ -238,7 +238,7 @@
     <p>
       <strong>Repository URL:</strong>
       <%= link_to @product.github_identifier,
-        "https://github.com/#{@product.github_identifier}", class: 'link--product'
+        "https://github.com/#{@product.github_identifier}", class: 'overflow-ellipsis'
       %>
     </p>
 
@@ -296,7 +296,7 @@
     <p><strong>Sharepoint Link</strong></p>
     <p>
      <% if !@product.sharepoint_link.blank? %>
-       <%= link_to @product.sharepoint_link, @product.sharepoint_link, target: '_blank', class: 'link--product' %>
+       <%= link_to @product.sharepoint_link, @product.sharepoint_link, target: '_blank', class: 'overflow-ellipsis' %>
       <% else %>
         This product has no Sharepoint link
       <% end %>
@@ -305,7 +305,7 @@
     <p><strong>Codebase Link</strong></p>
     <p>
       <% if !@product.codebase_url.blank? %>
-       <%= link_to @product.codebase_url, @product.codebase_url, target: '_blank', class: 'link--product' %>
+       <%= link_to @product.codebase_url, @product.codebase_url, target: '_blank', class: 'overflow-ellipsis' %>
       <% else %>
         This product has no Codebase link
       <% end %>
@@ -316,7 +316,7 @@
     <p><strong>Adobe XD design Link</strong></p>
     <p>
       <% if !@product.design_link.blank? %>
-       <%= link_to @product.design_link, @product.design_link, target: '_blank', class: 'link--product' %>
+       <%= link_to @product.design_link, @product.design_link, target: '_blank', class: 'overflow-ellipsis' %>
       <% else %>
         This product has no design link
       <% end %>


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/bits-and-bugs/tickets/53

Crop long URLs using CSS on the products page (all links apart from the deprecated links should have the new class on the link helper). 